### PR TITLE
Fix expiry warning

### DIFF
--- a/lib/hammer/supervisor.ex
+++ b/lib/hammer/supervisor.ex
@@ -50,7 +50,7 @@ defmodule Hammer.Supervisor do
     ]
 
     args = [
-      expiry_ms: decoded_query["expiry_ms"],
+      expiry_ms: expiry_ms,
       redix_config: [host: host, port: port]
     ]
 


### PR DESCRIPTION
## Purpose
There is currently a warning thrown by any app that includes this library about `expiry_ms`. This is caused by the argument for it being called incorrectly. It was previously updated, but then the variable wasn't referenced in the returned args.